### PR TITLE
Add an operations link for nodes with Layout Builder enabled

### DIFF
--- a/varbase_layout_builder.module
+++ b/varbase_layout_builder.module
@@ -15,7 +15,7 @@ use Drupal\varbase_layout_builder\Form\VarbaseLayoutBuilderConfigureSectionForm;
 /**
  * Implements hook_entity_operation().
  */
-function varbase_layout_builder_link_entity_operation(EntityInterface $entity) {
+function varbase_layout_builder_entity_operation(EntityInterface $entity) {
   $account = \Drupal::currentUser();
   $entity_type_id = $entity->getEntityTypeId();
 

--- a/varbase_layout_builder.module
+++ b/varbase_layout_builder.module
@@ -5,10 +5,42 @@
  * Contains varbase_layout_builder.module.
  */
 
+use Drupal\Core\Url;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media\Entity\Media;
 use Drupal\file\Entity\File;
 use Drupal\varbase_layout_builder\Form\VarbaseLayoutBuilderConfigureSectionForm;
+
+/**
+ * Implements hook_entity_operation().
+ */
+function varbase_layout_builder_link_entity_operation(EntityInterface $entity) {
+  $account = \Drupal::currentUser();
+  $entity_type_id = $entity->getEntityTypeId();
+
+  $route_name = "layout_builder.overrides.$entity_type_id.view";
+  $route_parameters = [
+    $entity_type_id => $entity->id(),
+  ];
+
+  // If current user has access to route, then add the operation link. The
+  // access check will only return TRUE if the bundle is Layout Builder-
+  // enabled, overrides are allowed, and user has necessary permissions.
+  $access_manager = \Drupal::service('access_manager');
+  if (!$access_manager->checkNamedRoute($route_name, $route_parameters, $account)) {
+    return;
+  }
+
+  return [
+    'Layout' => [
+      'title' => t('Layout'),
+      'weight' => 50,
+      'url' => Url::fromRoute($route_name, $route_parameters),
+    ],
+  ];
+}
+
 
 /**
  * Implements hook_form_alter().

--- a/varbase_layout_builder.module
+++ b/varbase_layout_builder.module
@@ -41,7 +41,6 @@ function varbase_layout_builder_entity_operation(EntityInterface $entity) {
   ];
 }
 
-
 /**
  * Implements hook_form_alter().
  */


### PR DESCRIPTION
It would be nice to have an operations link for nodes with Layout Builder enabled.

Adding a `hook_entity_operation` in our varbase_layout_builder module is more than enough.